### PR TITLE
Enhance focus ring accessibility

### DIFF
--- a/pattern.jst
+++ b/pattern.jst
@@ -1,0 +1,14 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.$data }}
+
+{{
+  var $regexp = $isData
+                ? '(new RegExp(' + $schemaValue + '))'
+                : it.usePattern($schema);
+}}
+
+if ({{# def.$dataNotType:'string' }} !{{=$regexp}}.test({{=$data}}) ) {
+  {{# def.error:'pattern' }}
+} {{? $breakOnError }} else { {{?}}


### PR DESCRIPTION
Improve keyboard focus visibility on interactive controls to meet WCAG contrast and make keyboard navigation obvious. Update CSS to use :focus-visible with a 2px solid accent color and a 4px outline-offset, and remove any custom box-shadow that currently hides native outlines.