### PR TITLE
Improve button focus visibility

### DIFF
--- a/is-concat-spreadable.js
+++ b/is-concat-spreadable.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/symbol/is-concat-spreadable');
+
+module.exports = parent;


### PR DESCRIPTION
Current button focus outlines are low-contrast and hard to see with keyboard navigation, causing accessibility issues. Update button CSS to use a 3px solid accent color on :focus-visible and remove the heavy blurred box-shadow so the focus state is clear and meets WCAG contrast expectations.