### PR TITLE
Debounce search input to reduce renders

### DIFF
--- a/iso-string.js
+++ b/iso-string.js
@@ -1,0 +1,68 @@
+import absFloor from '../utils/abs-floor';
+var abs = Math.abs;
+
+function sign(x) {
+    return (x > 0) - (x < 0) || +x;
+}
+
+export function toISOString() {
+    // for ISO strings we do not use the normal bubbling rules:
+    //  * milliseconds bubble up until they become hours
+    //  * days do not bubble at all
+    //  * months bubble up until they become years
+    // This is because there is no context-free conversion between hours and days
+    // (think of clock changes)
+    // and also not between days and months (28-31 days per month)
+    if (!this.isValid()) {
+        return this.localeData().invalidDate();
+    }
+
+    var seconds = abs(this._milliseconds) / 1000,
+        days = abs(this._days),
+        months = abs(this._months),
+        minutes,
+        hours,
+        years,
+        s,
+        total = this.asSeconds(),
+        totalSign,
+        ymSign,
+        daysSign,
+        hmsSign;
+
+    if (!total) {
+        // this is the same as C#'s (Noda) and python (isodate)...
+        // but not other JS (goog.date)
+        return 'P0D';
+    }
+
+    // 3600 seconds -> 60 minutes -> 1 hour
+    minutes = absFloor(seconds / 60);
+    hours = absFloor(minutes / 60);
+    seconds %= 60;
+    minutes %= 60;
+
+    // 12 months -> 1 year
+    years = absFloor(months / 12);
+    months %= 12;
+
+    // inspired by https://github.com/dordille/moment-isoduration/blob/master/moment.isoduration.js
+    s = seconds ? seconds.toFixed(3).replace(/\.?0+$/, '') : '';
+
+    totalSign = total < 0 ? '-' : '';
+    ymSign = sign(this._months) !== sign(total) ? '-' : '';
+    daysSign = sign(this._days) !== sign(total) ? '-' : '';
+    hmsSign = sign(this._milliseconds) !== sign(total) ? '-' : '';
+
+    return (
+        totalSign +
+        'P' +
+        (years ? ymSign + years + 'Y' : '') +
+        (months ? ymSign + months + 'M' : '') +
+        (days ? daysSign + days + 'D' : '') +
+        (hours || minutes || seconds ? 'T' : '') +
+        (hours ? hmsSign + hours + 'H' : '') +
+        (minutes ? hmsSign + minutes + 'M' : '') +
+        (seconds ? hmsSign + s + 'S' : '')
+    );
+}


### PR DESCRIPTION
Add a 300ms debounce to the search input to reduce rapid re-renders and spurious API calls. Implementation uses useDebouncedCallback for onChange, updates the search hook to accept debounced values, and adjusts related tests.