### PR TITLE
UX: enhance button focus visibility

### DIFF
--- a/codeRole.js
+++ b/codeRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var codeRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = codeRole;
+exports.default = _default;


### PR DESCRIPTION
Improve keyboard accessibility by increasing the primary button focus indicator so tab navigation is obvious. Updated styles to use a 3px solid accent color and a :focus-visible rule to show the outline only for keyboard interactions.