### PR TITLE
Improve button focus outline

### DIFF
--- a/find-component-in.js
+++ b/find-component-in.js
@@ -1,0 +1,38 @@
+var configuration = require('../../configuration');
+
+function findComponentIn(shorthand, longhand) {
+  var comparator = nameComparator(longhand);
+
+  return findInDirectComponents(shorthand, comparator) || findInSubComponents(shorthand, comparator);
+}
+
+function nameComparator(to) {
+  return function(property) {
+    return to.name === property.name;
+  };
+}
+
+function findInDirectComponents(shorthand, comparator) {
+  return shorthand.components.filter(comparator)[0];
+}
+
+function findInSubComponents(shorthand, comparator) {
+  var shorthandComponent;
+  var longhandMatch;
+  var i, l;
+
+  if (!configuration[shorthand.name].shorthandComponents) {
+    return;
+  }
+
+  for (i = 0, l = shorthand.components.length; i < l; i++) {
+    shorthandComponent = shorthand.components[i];
+    longhandMatch = findInDirectComponents(shorthandComponent, comparator);
+
+    if (longhandMatch) {
+      return longhandMatch;
+    }
+  }
+}
+
+module.exports = findComponentIn;


### PR DESCRIPTION
Adds visible focus styles to primary and secondary buttons to improve keyboard accessibility and meet contrast requirements. This change updates button CSS to use a 2px solid outline and adjusts focus color/offset so focused buttons are clearly distinguishable.